### PR TITLE
chore (rocket.chat): bump app version to 7.11.0

### DIFF
--- a/charts/apps/rocketchat/Chart.yaml
+++ b/charts/apps/rocketchat/Chart.yaml
@@ -3,7 +3,7 @@ name: rocketchat
 description: Rocket.Chat with SSO and some useful extras
 type: application
 version: "0.6.2"
-appVersion: "7.7.9"
+appVersion: "7.11.0"
 
 dependencies:
   - name: common

--- a/charts/apps/rocketchat/templates/rocketchat.yaml
+++ b/charts/apps/rocketchat/templates/rocketchat.yaml
@@ -131,7 +131,7 @@ spec:
   chart:
     spec:
       chart: rocketchat
-      version: '6.26.0'
+      version: '6.27.1'
       sourceRef:
         kind: HelmRepository
         name: rocketchat


### PR DESCRIPTION
At the queerkastle rocket chat we received a warning, that we need to update to at least 7.7.0.
Thus, I updated the version to 7.7.9 (hopefully at the right place).

I was wondering, did you manually update our instance to 7.6.0? Because according to the repository it should have been on 7.4.1 before.

If I did not follow the conventions of versioning for this repository, please correct me.

Kind regards,
Leo :) 

<img width="449" height="552" alt="image" src="https://github.com/user-attachments/assets/740bed3a-ed29-4d38-86e2-c37faaba6b1d" />
