### PR TITLE
chore (rocket.chat): bump app version to 8.2.0

### DIFF
--- a/charts/apps/rocketchat/Chart.yaml
+++ b/charts/apps/rocketchat/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rocketchat
 description: Rocket.Chat with SSO and some useful extras
 type: application
-version: "0.6.3"
-appVersion: "7.11.0"
+version: "0.6.4"
+appVersion: "8.2.0"
 
 dependencies:
   - name: common

--- a/charts/apps/rocketchat/templates/rocketchat.yaml
+++ b/charts/apps/rocketchat/templates/rocketchat.yaml
@@ -131,7 +131,7 @@ spec:
   chart:
     spec:
       chart: rocketchat
-      version: '6.27.1'
+      version: '6.32.1'
       sourceRef:
         kind: HelmRepository
         name: rocketchat


### PR DESCRIPTION
So accroding to https://docs.rocket.chat/docs/version-durability, the currently served version (App 7.11) will be EOL at the end of april.

I saw no major changes at https://github.com/RocketChat/Rocket.Chat/releases, so I think upgrading to the latest version of rocket chat makes sense. 
I upgraded to chart 6.32.1, which corresponds to App 8.2.0 (https://artifacthub.io/packages/helm/rocketchat-server/rocketchat).

Best regards,
Leo